### PR TITLE
Remove piracy to BitBasis

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,7 +12,7 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [compat]
 AbstractTrees = "0.4"
-BitBasis = "0.9.6"
+BitBasis = "0.9.10"
 Combinatorics = "1.0.2"
 Graphs = "1.11.2"
 SparseArrays = "1.8"

--- a/src/bitbasis.jl
+++ b/src/bitbasis.jl
@@ -1,5 +1,3 @@
-Base.show(io::IO, val::LongLongUInt{C}) where{C} = print(io, BitStr{64 * C}(val))
-
 function bit2id(bit::INT, N::Int) where{INT}
     id = Vector{Int}()
     for i in 1:N
@@ -8,13 +6,4 @@ function bit2id(bit::INT, N::Int) where{INT}
         end
     end
     return id
-end
-
-function Base.hash(bits_tuple::Tuple{LongLongUInt{C}, Vararg{LongLongUInt{C}, M}}) where{M, C}
-    N = M + 1
-    hash0 = Base.hash(bits_tuple[1].content)
-    for i in 2:N
-        hash0 = Base.hash(bits_tuple[i].content, hash0)
-    end
-    return hash0
 end

--- a/test/bitbasis.jl
+++ b/test/bitbasis.jl
@@ -7,11 +7,3 @@ using TreeWidthSolver: bit2id
     b = bmask(LongLongUInt{2}, 1:65)
     @test bit2id(b, 128) == collect(1:65)
 end
-
-@testset "LongLongUInt hash" begin
-    b1 = bmask(LongLongUInt{1}, 1)
-    b2 = bmask(LongLongUInt{1}, 2)
-    b3 = bmask(LongLongUInt{1}, 3)
-
-    @test hash((b1, b2, b3)) == hash((b1, b2, b3))
-end


### PR DESCRIPTION
The piracy is very dangerous in general.
It also causes relevant packages to repeatedly compile due to the method invalidation.

I added the relevant methods to BitBasis@v0.9.10 so that you do not need to pirate BitBasis anymore.